### PR TITLE
fix: using math.evaluate instead of eval method

### DIFF
--- a/minimalCalc/index.html
+++ b/minimalCalc/index.html
@@ -60,6 +60,7 @@
       <div id="desert" class="flex themebtn">Desert</div>
       <div id="dark" class="flex themebtn">Night</div>
     </footer>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/9.4.4/math.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/minimalCalc/index.js
+++ b/minimalCalc/index.js
@@ -155,7 +155,11 @@ equal.addEventListener("click", () => {
 });
 
 function calculateResult(expression) {
-  return parseFloat(eval(expression).toFixed(3));
+  try {
+    return math.evaluate(expression);
+  } catch (error) {
+    return "Error";
+  }
 }
 
 sea.addEventListener("click", () => {


### PR DESCRIPTION
The eval() function is considered dangerous because it can execute any code passed to it. 

Instead, using the library `math.js` which is designed for this purpose and is safer.